### PR TITLE
feat: add option for cover image on journal posts

### DIFF
--- a/src/assets/styles/critical/journal.css
+++ b/src/assets/styles/critical/journal.css
@@ -128,13 +128,23 @@
 	}
 }
 
+/** Cover image */
+.journal-post-cover-image {
+	grid-column: 1 / -1;
+
+	@media (--tablet) {
+		grid-column: 1 / 13;
+		grid-row: 2;
+	}
+}
+
 /** Journal Detail Page Meta */
 .journal-post-meta {
 	grid-column: 2 / -2;
-	grid-row: 2;
 
 	@media (--tablet) {
 		grid-column: -6 / -3;
+		grid-row: 2;
 	}
 }
 

--- a/src/layouts/journal-detail.njk
+++ b/src/layouts/journal-detail.njk
@@ -8,6 +8,11 @@ css: journal.css
 
 <article class="journal-post-container">
 	<h1 class="journal-post-title">{{ title | nbsp | safe }}</h1>
+	{% if cover %}
+		<div class="journal-post-cover-image">
+			<img src="/assets/images/covers/{{ cover }}" alt="{{ title }}" />
+		</div>
+	{% endif %}
 	<aside class="journal-post-meta">
 		<div class="journal-post-meta-author">
 			<em>By</em>
@@ -20,7 +25,7 @@ css: journal.css
 		</div>
 		<div class="journal-post-meta-time">
 			{{ content | striptags(true) | wordcount }}
-			<span class="journal-post-meta-time-fragment">words</span> • 
+			<span class="journal-post-meta-time-fragment">words</span> •
       {{ content | readingTime }}
 			<span class="journal-post-meta-time-fragment">read</span>
 		</div>
@@ -36,4 +41,3 @@ css: journal.css
 	</div>
 	{% include "pagination.njk" %}
 </article>
-

--- a/src/posts/2022/tools-for-better-writing.md
+++ b/src/posts/2022/tools-for-better-writing.md
@@ -14,7 +14,7 @@ I plan to improve the internal documentation of my company’s Design System. I 
 
 Writing good text consists of two components, correct translation, and error-free, understandable writing.
 
-***
+---
 
 ## Translation
 
@@ -34,7 +34,7 @@ Full-page translations and full document translations are exclusive to the DeepL
 
 I’m using the [DeepL API](https://www.deepl.com/pro-api/) (500,000 characters are free per month) to directly translate in Raycast with the [Deepcast](https://www.raycast.com/mooxl/deepcast) application.
 
-***
+---
 
 ## Dictionaries & Thesaurus
 
@@ -77,7 +77,7 @@ The platform has good resources for learning English with games, lists, flashcar
 - [Jisho](https://jisho.org/) is a minimalistic Japanese dictionary, including animations and stroke order for Kanji.
 - [Tangorin](https://tangorin.com/) is a website with a dictionary and vocabulary lists of widely used learning systems like JLPT or Jōyō.
 
-***
+---
 
 ## Copywriting
 


### PR DESCRIPTION
Providing a YAML frontmatter property of `cover` with a image name will show a cover image.